### PR TITLE
Add docker-compose stack for one-command local boot

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,17 @@
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+.coverage
+coverage.xml
+*.egg-info
+buildingpulse_backend.egg-info
+var/
+tests/
+dataexploration/
+training/
+.venv
+.env
+.env.*

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential curl \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml ./
+COPY app ./app
+COPY scripts ./scripts
+COPY artifacts ./artifacts
+
+RUN pip install .
+
+RUN mkdir -p /app/var
+
+ENV DB_PATH=/app/var/buildingpulse.db
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=10s --timeout=3s --retries=10 --start-period=20s \
+  CMD curl -fsS http://127.0.0.1:8000/openapi.json >/dev/null || exit 1
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pydantic>=2.8",
     "uvicorn[standard]>=0.30",
     "structlog>=25.0",
+    "httpx>=0.27",
     "opentelemetry-api>=1.30",
     "opentelemetry-sdk>=1.30",
     "opentelemetry-exporter-otlp>=1.30",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  backend:
+    build:
+      context: ./backend
+    image: buildingpulse-backend:dev
+    ports:
+      - "8000:8000"
+    environment:
+      DB_PATH: /app/var/buildingpulse.db
+    volumes:
+      - backend-var:/app/var
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8000/openapi.json"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
+    image: buildingpulse-frontend:dev
+    ports:
+      - "3000:3000"
+    depends_on:
+      backend:
+        condition: service_healthy
+
+volumes:
+  backend-var:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+out
+test-results
+playwright-report
+.eslintcache
+.env
+.env.*
+coverage
+*.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/package-lock.json ./package-lock.json
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.ts ./next.config.ts
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary

Adds a `docker compose up` path so the full stack — FastAPI backend + Next.js frontend — boots with one command. No more two-terminal dance.

- `backend/Dockerfile` — `python:3.11-slim`, installs the package, runs `uvicorn app.main:app` on `:8000`, healthcheck on `/openapi.json`.
- `frontend/Dockerfile` — multi-stage `node:20-alpine` (deps → build → runtime). `NEXT_PUBLIC_API_BASE_URL` is a build ARG (Next inlines public env at build time) and defaults to `http://localhost:8000`, which is what the browser sees once the host port is mapped.
- `docker-compose.yml` — bridge network, `backend` healthcheck gates frontend startup, SQLite DB persisted to a named volume `backend-var`.

## One drive-by fix

`opentelemetry-instrumentation-httpx` imports `httpx` at module load, but `httpx` was not declared in `backend/pyproject.toml` runtime deps. The container crashed on startup until I added it. This was a latent bug — local dev only worked because `httpx` came in transitively from a dev extra. Added `httpx>=0.27` to runtime deps.

## How to run

```bash
docker compose up -d --build
# backend:  http://localhost:8000/docs
# frontend: http://localhost:3000
docker compose down
```

## Verification

Boot test on this branch:

| check | result |
| --- | --- |
| docker compose build | both images built |
| docker compose ps after up -d | backend healthy, frontend Up |
| GET /openapi.json | 200 |
| GET / (frontend) | 307 (Next default redirect) |

## Notes / follow-ups (not in this PR)

- Backend CORS is hardcoded to http://localhost:3000. Fine for compose, but production origins still need to be wired.
- Frontend uses NEXT_PUBLIC_API_BASE_URL for client-side fetches only. If anything starts doing SSR fetches against the API later, we'll need a separate INTERNAL_API_BASE_URL=http://backend:8000 runtime env.

## Test plan

- [ ] docker compose up -d --build brings both services up
- [ ] http://localhost:3000 loads the frontend
- [ ] http://localhost:8000/docs shows the FastAPI swagger UI
- [ ] docker compose down -v cleans up cleanly