### PR TITLE
Fix PDF download: send required query params + persist email

### DIFF
--- a/frontend/src/app/report/[id]/page.tsx
+++ b/frontend/src/app/report/[id]/page.tsx
@@ -55,8 +55,9 @@ export default function ReportPage({ params }: { params: Promise<{ id: string }>
   const { id } = use(params);
   const [leadOpen, setLeadOpen] = React.useState(false);
 
-  const { isUnlocked, unlock } = useUnlock();
+  const { isUnlocked, unlock, emailFor } = useUnlock();
   const unlocked = isUnlocked(id);
+  const unlockedEmail = emailFor(id);
 
   const query = usePrediction(id);
   const onChooseScenario = useChooseScenario(id);
@@ -156,7 +157,22 @@ export default function ReportPage({ params }: { params: Promise<{ id: string }>
           <InfoCard title="Building Profile" rows={profile} />
 
           <ActionColumn>
-            <ExportPdfButton predictionId={id} unlocked={unlocked} />
+            <ExportPdfButton
+              predictionId={id}
+              unlocked={unlocked}
+              params={
+                unlockedEmail
+                  ? {
+                      email: unlockedEmail,
+                      propertyType: prediction.input.propertyType,
+                      borough: prediction.input.borough,
+                      grossFloorAreaSqft: prediction.input.grossFloorAreaSqft,
+                      yearBuilt: prediction.input.yearBuilt,
+                      numberOfBuildings: prediction.input.numberOfBuildings,
+                    }
+                  : null
+              }
+            />
             <Button
               variant="secondary"
               width="full"
@@ -207,7 +223,7 @@ export default function ReportPage({ params }: { params: Promise<{ id: string }>
       <LeadModal
         open={leadOpen}
         onClose={() => setLeadOpen(false)}
-        onSuccess={() => unlock(id)}
+        onSuccess={(_leadId, email) => unlock(id, email)}
         context={buildLeadContext(id, prediction)}
       />
     </div>

--- a/frontend/src/components/modal/lead-modal.tsx
+++ b/frontend/src/components/modal/lead-modal.tsx
@@ -38,7 +38,7 @@ export interface LeadModalContext {
 export interface LeadModalProps {
   open: boolean;
   onClose: () => void;
-  onSuccess: (leadId: string) => void;
+  onSuccess: (leadId: string, email: string) => void;
   context: LeadModalContext;
 }
 
@@ -128,7 +128,7 @@ export function LeadModal({ open, onClose, onSuccess, context }: LeadModalProps)
 
     capture.mutate(input, {
       onSuccess: (response) => {
-        onSuccess(response.data.id);
+        onSuccess(response.data.id, input.email);
         onClose();
       },
       onError: () => {

--- a/frontend/src/components/report/export-pdf-button.tsx
+++ b/frontend/src/components/report/export-pdf-button.tsx
@@ -4,25 +4,26 @@ import * as React from "react";
 import { Download } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { usePdfDownload } from "@/hooks/use-pdf-download";
+import { usePdfDownload, type PdfDownloadParams } from "@/hooks/use-pdf-download";
 
 interface ExportPdfButtonProps {
   predictionId: string;
   unlocked: boolean;
+  params: PdfDownloadParams | null;
 }
 
 const LOCKED_HINT = "Unlock the report by sharing your contact info to download the PDF.";
 
-export function ExportPdfButton({ predictionId, unlocked }: ExportPdfButtonProps) {
+export function ExportPdfButton({ predictionId, unlocked, params }: ExportPdfButtonProps) {
   const { status, error, download, reset } = usePdfDownload();
   const isDownloading = status === "downloading";
   const isError = status === "error";
-  const disabled = !unlocked || isDownloading;
+  const disabled = !unlocked || isDownloading || params === null;
 
   const handleClick = () => {
-    if (!unlocked) return;
+    if (!unlocked || params === null) return;
     if (isError) reset();
-    void download(predictionId);
+    void download(predictionId, params);
   };
 
   return (

--- a/frontend/src/hooks/use-pdf-download.ts
+++ b/frontend/src/hooks/use-pdf-download.ts
@@ -2,14 +2,25 @@
 
 import * as React from "react";
 
+import type { BuildingBorough, BuildingPropertyType } from "@/types";
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 export type PdfDownloadStatus = "idle" | "downloading" | "error";
 
+export interface PdfDownloadParams {
+  email: string;
+  propertyType: BuildingPropertyType;
+  borough: BuildingBorough;
+  grossFloorAreaSqft: number;
+  yearBuilt: number;
+  numberOfBuildings: number;
+}
+
 export interface UsePdfDownloadReturn {
   status: PdfDownloadStatus;
   error: string | null;
-  download: (predictionId: string) => Promise<void>;
+  download: (predictionId: string, params: PdfDownloadParams) => Promise<void>;
   reset: () => void;
 }
 
@@ -22,31 +33,40 @@ export function usePdfDownload(): UsePdfDownloadReturn {
     setError(null);
   }, []);
 
-  const download = React.useCallback(async (predictionId: string) => {
-    setStatus("downloading");
-    setError(null);
-    try {
-      const base =
-        API_BASE_URL ||
-        (typeof window !== "undefined" ? window.location.origin : "http://localhost");
-      const url = new URL(`/api/predictions/${predictionId}/pdf`, base).toString();
+  const download = React.useCallback(
+    async (predictionId: string, params: PdfDownloadParams) => {
+      setStatus("downloading");
+      setError(null);
+      try {
+        const base =
+          API_BASE_URL ||
+          (typeof window !== "undefined" ? window.location.origin : "http://localhost");
+        const url = new URL(`/api/predictions/${predictionId}/pdf`, base);
+        url.searchParams.set("email", params.email);
+        url.searchParams.set("propertyType", params.propertyType);
+        url.searchParams.set("borough", params.borough);
+        url.searchParams.set("grossFloorAreaSqft", String(params.grossFloorAreaSqft));
+        url.searchParams.set("yearBuilt", String(params.yearBuilt));
+        url.searchParams.set("numberOfBuildings", String(params.numberOfBuildings));
 
-      const response = await fetch(url, { method: "GET" });
-      if (!response.ok) {
-        throw new Error(`Download failed (HTTP ${response.status})`);
+        const response = await fetch(url.toString(), { method: "GET" });
+        if (!response.ok) {
+          throw new Error(`Download failed (HTTP ${response.status})`);
+        }
+
+        const blob = await response.blob();
+        const filename =
+          parseFilename(response.headers.get("content-disposition")) ??
+          `building-pulse-${predictionId}.pdf`;
+        triggerBrowserDownload(blob, filename);
+        setStatus("idle");
+      } catch (e) {
+        setStatus("error");
+        setError(e instanceof Error ? e.message : "Download failed");
       }
-
-      const blob = await response.blob();
-      const filename =
-        parseFilename(response.headers.get("content-disposition")) ??
-        `building-pulse-${predictionId}.pdf`;
-      triggerBrowserDownload(blob, filename);
-      setStatus("idle");
-    } catch (e) {
-      setStatus("error");
-      setError(e instanceof Error ? e.message : "Download failed");
-    }
-  }, []);
+    },
+    [],
+  );
 
   return { status, error, download, reset };
 }

--- a/frontend/src/providers/unlock-provider.tsx
+++ b/frontend/src/providers/unlock-provider.tsx
@@ -4,13 +4,15 @@ import * as React from "react";
 
 const STORAGE_KEY = "buildingpulse:unlocked-reports";
 
+export type UnlockEntry = { reportId: string; email: string | null };
+
 export type UnlockState = {
-  unlocked: ReadonlyArray<string>;
+  unlocked: ReadonlyArray<UnlockEntry>;
 };
 
 export type UnlockAction =
-  | { type: "unlock"; reportId: string }
-  | { type: "hydrate"; reportIds: ReadonlyArray<string> }
+  | { type: "unlock"; reportId: string; email: string | null }
+  | { type: "hydrate"; entries: ReadonlyArray<UnlockEntry> }
   | { type: "reset" };
 
 export const initialUnlockState: UnlockState = { unlocked: [] };
@@ -18,11 +20,15 @@ export const initialUnlockState: UnlockState = { unlocked: [] };
 export function unlockReducer(state: UnlockState, action: UnlockAction): UnlockState {
   switch (action.type) {
     case "unlock": {
-      if (state.unlocked.includes(action.reportId)) return state;
-      return { unlocked: [...state.unlocked, action.reportId] };
+      const existingIdx = state.unlocked.findIndex((e) => e.reportId === action.reportId);
+      const next: UnlockEntry = { reportId: action.reportId, email: action.email };
+      if (existingIdx === -1) return { unlocked: [...state.unlocked, next] };
+      const merged = [...state.unlocked];
+      merged[existingIdx] = { ...merged[existingIdx]!, email: action.email ?? merged[existingIdx]!.email };
+      return { unlocked: merged };
     }
     case "hydrate": {
-      return { unlocked: [...action.reportIds] };
+      return { unlocked: [...action.entries] };
     }
     case "reset": {
       if (state.unlocked.length === 0) return state;
@@ -33,29 +39,41 @@ export function unlockReducer(state: UnlockState, action: UnlockAction): UnlockS
 
 interface UnlockContextValue {
   isUnlocked: (reportId: string) => boolean;
-  unlock: (reportId: string) => void;
+  emailFor: (reportId: string) => string | null;
+  unlock: (reportId: string, email?: string | null) => void;
   reset: () => void;
 }
 
 const UnlockContext = React.createContext<UnlockContextValue | null>(null);
 
-function readSession(): ReadonlyArray<string> {
+function readSession(): ReadonlyArray<UnlockEntry> {
   if (typeof window === "undefined") return [];
   try {
     const raw = window.sessionStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter((v): v is string => typeof v === "string");
+    return parsed.flatMap((v): UnlockEntry[] => {
+      if (typeof v === "string") return [{ reportId: v, email: null }];
+      if (
+        v &&
+        typeof v === "object" &&
+        typeof (v as { reportId?: unknown }).reportId === "string"
+      ) {
+        const obj = v as { reportId: string; email?: unknown };
+        return [{ reportId: obj.reportId, email: typeof obj.email === "string" ? obj.email : null }];
+      }
+      return [];
+    });
   } catch {
     return [];
   }
 }
 
-function writeSession(ids: ReadonlyArray<string>): void {
+function writeSession(entries: ReadonlyArray<UnlockEntry>): void {
   if (typeof window === "undefined") return;
   try {
-    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
   } catch {
     // ignore
   }
@@ -65,8 +83,8 @@ export function UnlockProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = React.useReducer(unlockReducer, initialUnlockState);
 
   React.useEffect(() => {
-    const ids = readSession();
-    if (ids.length > 0) dispatch({ type: "hydrate", reportIds: ids });
+    const entries = readSession();
+    if (entries.length > 0) dispatch({ type: "hydrate", entries });
   }, []);
 
   React.useEffect(() => {
@@ -75,8 +93,11 @@ export function UnlockProvider({ children }: { children: React.ReactNode }) {
 
   const value = React.useMemo<UnlockContextValue>(
     () => ({
-      isUnlocked: (reportId: string) => state.unlocked.includes(reportId),
-      unlock: (reportId: string) => dispatch({ type: "unlock", reportId }),
+      isUnlocked: (reportId: string) => state.unlocked.some((e) => e.reportId === reportId),
+      emailFor: (reportId: string) =>
+        state.unlocked.find((e) => e.reportId === reportId)?.email ?? null,
+      unlock: (reportId: string, email: string | null = null) =>
+        dispatch({ type: "unlock", reportId, email }),
       reset: () => dispatch({ type: "reset" }),
     }),
     [state.unlocked],


### PR DESCRIPTION
## Summary

The PDF download was returning **HTTP 422** for every click. Two bugs:

1. The frontend hook fired `GET /api/predictions/{id}/pdf` with no query string. The backend requires seven query params (email, propertyType, borough, grossFloorAreaSqft, yearBuilt, numberOfBuildings).
2. The captured email was discarded after lead submission. `unlock(reportId)` only stored the id, so by the time the user clicked Export the email was gone — even if we'd been sending it, we wouldn't have had it.

## What this PR does

- **`unlock-provider.tsx`** — store `{ reportId, email }` entries instead of bare strings. New `emailFor(reportId)` selector. Includes a migration shim so old `string[]` entries already in `sessionStorage` keep working as anonymous unlocks.
- **`lead-modal.tsx`** — `onSuccess` now passes the captured email up: `(leadId, email) => void`.
- **`use-pdf-download.ts`** — `download(predictionId, params)` builds `URLSearchParams` from a typed `PdfDownloadParams` object whose keys match the backend's `Query(alias=...)` names exactly (`propertyType`, `grossFloorAreaSqft`, etc.).
- **`export-pdf-button.tsx`** — takes a `params: PdfDownloadParams | null` prop. Button is disabled when `null` (covers both pre-unlock and the legacy session-storage migration case).
- **`report/[id]/page.tsx`** — looks up the email via `emailFor(id)`, builds the params object from `prediction.input`, passes both into the button.

## Verification

```
docker compose up -d --build
# 1. fill form  → 2. predict  → 3. unlock with lead form  → 4. click Export Full PDF Report
# Network tab now shows GET /api/predictions/<id>/pdf?email=...&propertyType=...&borough=...&...
# Browser triggers a download named building-pulse-<id>.pdf
```

## Test plan

- [ ] Pre-unlock: Export button is disabled with the lock hint
- [ ] After lead submit: Export button is enabled and triggers a PDF download
- [ ] Refresh the report page after unlock → button still works (sessionStorage carries the email)
- [ ] Unit tests in `use-pdf-download.test.tsx` and `export-pdf-button.test.tsx` will need an update for the new signatures — flagging here, can land as a follow-up